### PR TITLE
make use of Now's alias functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ $ IPDB_APP_ID=123 IPDB_APP_KEY=123456 node start
 By default it binds to `0.0.0.0:9984`, if you want to change port use
 the env variable `IPDB_PORT`.
 
-# Running with Docker
+## Running with Docker
 
 ```
 docker run -e IPDB_APP_ID=<app_id> -e IPDB_APP_KEY=<app_key> -p 9984:9984 bigchaindb/ipdb-proxy
@@ -23,3 +23,18 @@ docker run -e IPDB_APP_ID=<app_id> -e IPDB_APP_KEY=<app_key> -p 9984:9984 bigcha
 - `IPDB_PORT`: Port to use when creating the server (default `9984`).
 - `IPDB_APP_ID`: the `app_id` to add to the headers of every request.
 - `IPDB_APP_KEY`: the (secret) `app_key` to add to the headers of every request.
+
+# Deployment
+
+Deploy to now, make sure to switch to BigchainDB org before deploying:
+
+```bash
+# first run
+now login
+now switch
+
+# deploy
+now
+# switch alias to new deployment
+now alias
+```

--- a/package.json
+++ b/package.json
@@ -12,5 +12,11 @@
     "cors": "^2.8.3",
     "express": "^4.15.3",
     "http-proxy-middleware": "^0.17.4"
+  },
+  "now": {
+    "alias": "ipdb-proxy.now.sh",
+    "env": {
+      "NODE_ENV": "production"
+    }
   }
 }


### PR DESCRIPTION
We don't want to change the endpoint on site after every deployment like in https://github.com/ascribe/bigchain-website/pull/150 so use Now's alias functionality. By adding the alias to the `package.json` all that's needed is an `now alias` after every new deployment.